### PR TITLE
Fix docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ RUN go install -v ./...
 
 
 # Runtime env
-FROM gcr.io/distroless/base:debug
+FROM alpine:3.10
 COPY --from=build /go/bin/tf-utils /
-ENTRYPOINT ["/tf-utils"]
+CMD ["/tf-utils"]


### PR DESCRIPTION
Jenkins doesn't work with images that have an entrypoint when using the
docker step https://issues.jenkins-ci.org/browse/JENKINS-54389
https://issues.jenkins-ci.org/browse/JENKINS-33149

Also the distroless base debug image seems broken and the busybox shell doesn't work
